### PR TITLE
Fixed Dailymotion embed behaviour when URL field is empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,9 +118,9 @@
 	function createDailymotionEmbed(){
 		var dailymotionURL = $("#dailymotion-url").val();
 		var dailymotionID = (m =dailymotionURL.match(new RegExp("\/video\/([^_?#]+).*?"))) ? m[1] : void 0;
-		var dailymotionEmbed = "&lt;iframe src='http://www.dailymotion.com/embed/video/" + dailymotionID + "' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen&gt;&lt;/iframe&gt;";
-		var dailymotionpreview = "<iframe src='http://www.dailymotion.com/embed/video/" + dailymotionID + "'  frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>";
-		
+		var dailymotionEmbed = "&lt;iframe src='http://www.dailymotion.com/embed/" + (dailymotionID ? 'video/'+dailymotionID : '') + "' frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen&gt;&lt;/iframe&gt;";
+		var dailymotionpreview = "<iframe src='http://www.dailymotion.com/embed/" + (dailymotionID ? 'video/'+dailymotionID : '') + "'  frameborder='0' webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>";
+
 		$("#dailymotionembedCode").html( embedLabel + "<textarea rows='12' class='codebox'>" + embedContainerCSS + embedContainerDivOpen + dailymotionEmbed + embedContainerDivClose + "</textarea>");
 		$("#dailymotionpreview").html( previewLabel + previewPrefix + dailymotionpreview + previewSuffix );
 	}


### PR DESCRIPTION
Just a quick fix to prevent Dailymotion embed to display an error page when the form is submitted without a URL.
 Cheers
